### PR TITLE
[HOLD] Add missing @material-ui/core exports

### DIFF
--- a/exports/@material-ui/core/4.10.1.json
+++ b/exports/@material-ui/core/4.10.1.json
@@ -113,5 +113,9 @@
   "./Tooltip": "./esm/Tooltip/Tooltip.js",
   "./Typography": "./esm/Typography/Typography.js",
   "./Unstable_TrapFocus": "./esm/Unstable_TrapFocus/Unstable_TrapFocus.js",
-  "./Zoom": "./esm/Zoom/Zoom.js"
+  "./Zoom": "./esm/Zoom/Zoom.js",
+  "./styles/*": "./styles/*.js",
+  "./utils/*": "./utils/*.js",
+  "./package.json": "./package.json",
+  "./": "./"
 }

--- a/exports/@material-ui/core/4.11.0.json
+++ b/exports/@material-ui/core/4.11.0.json
@@ -117,5 +117,9 @@
   "./Tooltip": "./esm/Tooltip/Tooltip.js",
   "./Typography": "./esm/Typography/Typography.js",
   "./Unstable_TrapFocus": "./esm/Unstable_TrapFocus/Unstable_TrapFocus.js",
-  "./Zoom": "./esm/Zoom/Zoom.js"
+  "./Zoom": "./esm/Zoom/Zoom.js",
+  "./styles/*": "./styles/*.js",
+  "./utils/*": "./utils/*.js",
+  "./package.json": "./package.json",
+  "./": "./"
 }

--- a/exports/@material-ui/core/4.8.0.json
+++ b/exports/@material-ui/core/4.8.0.json
@@ -110,5 +110,9 @@
   "./Toolbar": "./esm/Toolbar/Toolbar.js",
   "./Tooltip": "./esm/Tooltip/Tooltip.js",
   "./Typography": "./esm/Typography/Typography.js",
-  "./Zoom": "./esm/Zoom/Zoom.js"
+  "./Zoom": "./esm/Zoom/Zoom.js",
+  "./styles/*": "./styles/*.js",
+  "./utils/*": "./utils/*.js",
+  "./package.json": "./package.json",
+  "./": "./"
 }

--- a/exports/@material-ui/core/4.9.13.json
+++ b/exports/@material-ui/core/4.9.13.json
@@ -112,5 +112,9 @@
   "./Toolbar": "./esm/Toolbar/Toolbar.js",
   "./Tooltip": "./esm/Tooltip/Tooltip.js",
   "./Typography": "./esm/Typography/Typography.js",
-  "./Zoom": "./esm/Zoom/Zoom.js"
+  "./Zoom": "./esm/Zoom/Zoom.js",
+  "./styles/*": "./styles/*.js",
+  "./utils/*": "./utils/*.js",
+  "./package.json": "./package.json",
+  "./": "./"
 }

--- a/exports/@material-ui/core/4.9.3.json
+++ b/exports/@material-ui/core/4.9.3.json
@@ -111,5 +111,9 @@
   "./Toolbar": "./esm/Toolbar/Toolbar.js",
   "./Tooltip": "./esm/Tooltip/Tooltip.js",
   "./Typography": "./esm/Typography/Typography.js",
-  "./Zoom": "./esm/Zoom/Zoom.js"
+  "./Zoom": "./esm/Zoom/Zoom.js",
+  "./styles/*": "./styles/*.js",
+  "./utils/*": "./utils/*.js",
+  "./package.json": "./package.json",
+  "./": "./"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,22 @@
 {
   "name": "DefinitelyExported",
-  "version": "1.0.0",
-  "lockfileVersion": 1,
+  "version": "0.0.1",
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "version": "0.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+    }
+  },
   "dependencies": {
     "semver": {
       "version": "7.3.2",


### PR DESCRIPTION
Need to hold until we have wildcard support. But this is another usecase where auto-expanding doesn‘t apply here